### PR TITLE
Add create button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint-plugin-react": "^7.34.1",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
+        "globals": "^15.0.0",
         "mongodb": "^6.5.0",
         "mongoose": "^8.3.1",
         "typescript-eslint": "^7.7.1",
@@ -622,6 +623,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/traverse/node_modules/ms": {
@@ -3955,12 +3965,14 @@
       }
     },
     "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.0.0.tgz",
+      "integrity": "sha512-m/C/yR4mjO6pXDTm9/R/SpYTAIyaUB4EOzcaaMEl7mds7Mshct9GfejiJNQGjHHbdMPey13Kpu4TMbYi9ex1pw==",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {

--- a/src/frontend/src/components/Button.tsx
+++ b/src/frontend/src/components/Button.tsx
@@ -10,6 +10,7 @@ type ButtonProps = {
   icon?: IconDefinition,
   className?: string,
   children: React.ReactNode,
+  disabled?: boolean;
 } & ({ onClick: () => void } | { href: string })
 
 function hasHref(props: unknown): props is { href: string } {
@@ -47,6 +48,7 @@ interface LinkButtonProps {
   href: string
   className: string
   children: React.ReactNode
+  disabled?: boolean
 }
 
 function LinkButton({ href, className, children }: LinkButtonProps) {
@@ -61,6 +63,7 @@ interface EventButtonProps {
   onClick: () => void
   className: string
   children: React.ReactNode
+  disabled?: boolean
 }
 
 function EventButton({ onClick, className, children }: EventButtonProps) {

--- a/src/frontend/src/components/SchemaForm.css
+++ b/src/frontend/src/components/SchemaForm.css
@@ -39,3 +39,10 @@
   justify-content: right;
   margin-top: 1rem;
 }
+
+.schema-form .fields .btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+
+}
+

--- a/src/frontend/src/components/SchemaForm.tsx
+++ b/src/frontend/src/components/SchemaForm.tsx
@@ -14,6 +14,7 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
   const [slug, setSlug] = useState<Schema["slug"]>("");
   const [fields, setFields] = useState<Schema["fields"]>([]);
   const [buttonClassName, setButtonClassName] = useState("btn-disabled");
+  const [schemaCreated, setSchemaCreated] = useState(false)
 
   useEffect(() => {
     onChange({ _id: "<unknown>", slug, fields });
@@ -48,12 +49,35 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
     e.preventDefault();
   }
 
+  const createSchema = async () => {
+    try {
+      const schemaData = {
+        slug,
+        fields
+      };
+      const response = await fetch ("api/schemas", { 
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(schemaData)
+      });
+      if (!response.ok) {
+        throw new Error ("Failed to create schema")
+      }
+      setSchemaCreated(true)
+      console.log("Schema created successfully")
+     } catch (error) {
+      console.error("Error creating schema:", error)
+     }
+  }
+
   const allFieldsFilled = fields.every(
     (fields) => fields.name.trim() !== "" && fields.formula.trim() !== ""
   );
 
   useEffect(() => {
-    setButtonClassName(allFieldsFilled ? "" : "btn-disabled");
+    setButtonClassName(allFieldsFilled && fields.length > 0 ? "" : "btn-disabled");
   }, [allFieldsFilled]);
 
   return (
@@ -103,9 +127,10 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
           </Button>
         </div>
         <div className="add-btn-container">
-          <Button className={buttonClassName} onClick={() => {}}>
+          <Button className={buttonClassName} onClick={createSchema}>
             Create Schema
           </Button>
+          {schemaCreated && <p>Schema created successfully!</p>}
         </div>
       </section>
     </form>

--- a/src/frontend/src/components/SchemaForm.tsx
+++ b/src/frontend/src/components/SchemaForm.tsx
@@ -55,7 +55,7 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
         slug,
         fields
       };
-      const response = await fetch ("api/schemas", { 
+      const response = await fetch ("/api/schemas", { 
         method: "POST",
         headers: {
           "Content-Type": "application/json"

--- a/src/frontend/src/components/SchemaForm.tsx
+++ b/src/frontend/src/components/SchemaForm.tsx
@@ -14,7 +14,7 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
   const [slug, setSlug] = useState<Schema["slug"]>("");
   const [fields, setFields] = useState<Schema["fields"]>([]);
   const [buttonClassName, setButtonClassName] = useState("btn-disabled");
-  const [schemaCreated, setSchemaCreated] = useState(false)
+  const [schemaCreated, setSchemaCreated] = useState(false);
 
   useEffect(() => {
     onChange({ _id: "<unknown>", slug, fields });
@@ -53,31 +53,33 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
     try {
       const schemaData = {
         slug,
-        fields
+        fields,
       };
-      const response = await fetch ("/api/schemas", { 
+      const response = await fetch("/api/schemas", {
         method: "POST",
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify(schemaData)
+        body: JSON.stringify(schemaData),
       });
       if (!response.ok) {
-        throw new Error ("Failed to create schema")
+        throw new Error("Failed to create schema");
       }
-      setSchemaCreated(true)
-      console.log("Schema created successfully")
-     } catch (error) {
-      console.error("Error creating schema:", error)
-     }
-  }
+      setSchemaCreated(true);
+      console.log("Schema created successfully");
+    } catch (error) {
+      console.error("Error creating schema:", error);
+    }
+  };
 
   const allFieldsFilled = fields.every(
     (fields) => fields.name.trim() !== "" && fields.formula.trim() !== ""
   );
 
   useEffect(() => {
-    setButtonClassName(allFieldsFilled && fields.length > 0 ? "" : "btn-disabled");
+    setButtonClassName(
+      allFieldsFilled && fields.length > 0 ? "" : "btn-disabled"
+    );
   }, [allFieldsFilled]);
 
   return (
@@ -130,8 +132,8 @@ export default function SchemaForm({ onChange }: SchemaFormProps) {
           <Button className={buttonClassName} onClick={createSchema}>
             Create Schema
           </Button>
-          {schemaCreated && <p>Schema created successfully!</p>}
-        </div>
+          </div>
+          <div className="add-btn-container"> {schemaCreated && <p>Schema created successfully!</p>} </div>  
       </section>
     </form>
   );

--- a/src/frontend/src/components/SchemaForm.tsx
+++ b/src/frontend/src/components/SchemaForm.tsx
@@ -1,5 +1,5 @@
 import TextInput from "./TextInput";
-import "./SchemaForm.css"
+import "./SchemaForm.css";
 import { useEffect, useState } from "react";
 import { Field, Schema } from "../types";
 import Button from "./Button";
@@ -7,75 +7,107 @@ import { faAdd, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import IconButton from "./IconButton";
 
 interface SchemaFormProps {
-  onChange: (schema: Schema) => void
+  onChange: (schema: Schema) => void;
 }
 
 export default function SchemaForm({ onChange }: SchemaFormProps) {
-
   const [slug, setSlug] = useState<Schema["slug"]>("");
   const [fields, setFields] = useState<Schema["fields"]>([]);
+  const [buttonClassName, setButtonClassName] = useState("btn-disabled");
 
   useEffect(() => {
-    onChange({ _id: "<unknown>", slug, fields })
-  }, [slug, fields, onChange])
+    onChange({ _id: "<unknown>", slug, fields });
+  }, [slug, fields, onChange]);
 
   function addField() {
-    setFields([...fields, { name: "", formula: "" }])
+    setFields([...fields, { name: "", formula: "" }]);
   }
 
   function removeField(idx: number) {
-    const newFields = [...fields]
-    newFields.splice(idx, 1)
-    setFields(newFields)
+    const newFields = [...fields];
+    newFields.splice(idx, 1);
+    setFields(newFields);
   }
 
   function updateField(idx: number, patch: Partial<Field>) {
-    const field = { ...fields.splice(idx, 1)[0], ...patch }
-    const newFields = [...fields]
-    newFields.splice(idx, 0, field)
-    setFields(newFields)
+    const field = { ...fields.splice(idx, 1)[0], ...patch };
+    const newFields = [...fields];
+    newFields.splice(idx, 0, field);
+    setFields(newFields);
   }
 
   function updateFieldName(idx: number, name: string) {
-    updateField(idx, { name })
+    updateField(idx, { name });
   }
 
   function updateFieldFormula(idx: number, formula: string) {
-    updateField(idx, { formula })
+    updateField(idx, { formula });
   }
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
+    e.preventDefault();
   }
+
+  const allFieldsFilled = fields.every(
+    (fields) => fields.name.trim() !== "" && fields.formula.trim() !== ""
+  );
+
+  useEffect(() => {
+    setButtonClassName(allFieldsFilled ? "" : "btn-disabled");
+  }, [allFieldsFilled]);
 
   return (
     <form className="schema-form" onSubmit={onSubmit}>
       <section className="metadata">
         <h2>Metadata</h2>
-        <TextInput label="Slug" id="schemaSlug" value={slug} onChange={e => setSlug(e.currentTarget.value)} />
+        <TextInput
+          label="Slug"
+          id="schemaSlug"
+          value={slug}
+          onChange={(e) => setSlug(e.currentTarget.value)}
+        />
       </section>
       <section className="fields">
         <h2>Fields</h2>
         <div>
           {fields.map((field, i) => (
             <div key={i} className="field">
-              <div className="field-number">
-                #{i + 1}
-              </div>
+              <div className="field-number">#{i + 1}</div>
               <div className="inputs">
-                <TextInput label="Name" id={`fieldName${i}`} value={field.name} onChange={e => updateFieldName(i, e.currentTarget.value)} />
-                <TextInput label="Formula" id={`fieldFormula${i}`} value={field.formula} onChange={e => updateFieldFormula(i, e.currentTarget.value)} />
+                <TextInput
+                  label="Name"
+                  id={`fieldName${i}`}
+                  value={field.name}
+                  onChange={(e) => updateFieldName(i, e.currentTarget.value)}
+                />
+                <TextInput
+                  label="Formula"
+                  id={`fieldFormula${i}`}
+                  value={field.formula}
+                  onChange={(e) => updateFieldFormula(i, e.currentTarget.value)}
+                />
               </div>
               <div className="controls">
-                <IconButton icon={faTrashAlt} variant="danger" onClick={() => removeField(i)} />
+                <IconButton
+                  icon={faTrashAlt}
+                  variant="danger"
+                  onClick={() => removeField(i)}
+                />
               </div>
             </div>
           ))}
         </div>
         <div className="add-btn-container">
-          <Button icon={faAdd} onClick={addField}>Add Field</Button>
+          <Button icon={faAdd} onClick={addField}>
+            Add Field
+          </Button>
+        </div>
+        <div className="add-btn-container">
+          <Button className={buttonClassName} onClick={() => {}}>
+            Create Schema
+          </Button>
         </div>
       </section>
     </form>
-  )
+  );
 }


### PR DESCRIPTION
fixes #4 

1. The create schema button should be disabled until all fields are filled out 
2. when the button is clicked it should send a POST request to db with the new schema showing on /schemas page
3. a message 'Schema created successfully!' to appear 